### PR TITLE
Update July 2021

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,8 @@ jobs:
       - run: docker build -t pyiron/continuum:latest continuum/
       - run: docker tag pyiron/continuum:latest pyiron/continuum:"$(date +%F)"
       - run: docker images
+      - run: docker run --rm pyiron/continuum /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
       - run: docker run --rm pyiron/base /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'  
       - run: docker run --rm pyiron/pyiron /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
       - run: docker run --rm pyiron/experimental /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
-      - run: docker run --rm pyiron/continuum /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
+      

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-stacks
-[![Build Status](https://travis-ci.com/pyiron/docker-stacks.svg?branch=master)](https://travis-ci.com/pyiron/docker-stacks)
+[![Docker Testing](https://github.com/pyiron/docker-stacks/workflows/Docker%20Push/badge.svg)](https://github.com/pyiron/docker-stacks/actions)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyiron/docker-stacks/master) 
 
 Here, one can find different flavours of Dockerfile for building pyiron docker images.   
@@ -24,7 +24,7 @@ replace `pyiron/pyiron` with the sepecific container you downloaded and to start
 docker run -i -t -p 8888:8888 pyiron/pyiron /bin/bash -c "source /opt/conda/bin/activate; jupyter lab --notebook-dir=/home/pyiron/ --ip='*' --port=8888"
 ```
 To explain the command: `docker run` starts the container in interactive mode `-i` by allocating a pseudo-TTY `-t`. The port `8888` of the docker container instance is forwarded to the local port `8888` the image of choice is `pyiron/pyiron` and inside the image the bash shell is used `/bin/bash` to execute the following command `-c`. First activate the conda environment by sourcing `source /opt/conda/bin/activate` and afterwars start either a jupyter notebook `jupyter notebook` or `jupyter lab` both in the home directory of the pyiron user `--notebook-dir=/home/pyiron/` and allow connections from any IP address `--ip='*'` on port 8888 `--port=8888` which is connected to the outside.   
-**Data persistence**  
+## Data persistence  
 You can mount your local drive on the home directory of the docker container via option `-v <local_path>:/home/pyiron/`:  
 ```
 docker run -i -t  -v <local_path>:/home/pyiron/ -p 8888:8888 pyiron/pyiron /bin/bash -c "source /opt/conda/bin/activate; jupyter notebook --notebook-dir=/home/pyiron/ --ip='*' --port=8888"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # docker-stacks
-[![Docker Testing](https://github.com/pyiron/docker-stacks/workflows/Docker%20Push/badge.svg)](https://github.com/pyiron/docker-stacks/actions)
+[![Build Status](https://travis-ci.com/pyiron/docker-stacks.svg?branch=master)](https://travis-ci.com/pyiron/docker-stacks)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyiron/docker-stacks/master) 
 
 Here, one can find different flavours of Dockerfile for building pyiron docker images.   
 The resulting images are:
 
-| Image name | Derived from | Additional Dependencies | Command | Size |
-|------------|--------------|-------------------------|---------|------|
-| pyiron/base | jupyter/base-notebook | <a href="https://anaconda.org/conda-forge/pyiron">pyiron_base</a> | `docker pull pyiron/base` | 1.27GB |
-| pyiron/md | pyiron/base | <a href="https://anaconda.org/conda-forge/lammps">LAMMPS</a>, <a href="https://anaconda.org/conda-forge/pyiron">pyiron</a>, <a href="https://anaconda.org/conda-forge/nglview">nglview</a> | `docker pull pyiron/md` | 2.90GB |
-| pyiron/pyiron | pyiron/md | <a href="https://anaconda.org/conda-forge/sphinxdft">SPHInX</a>, <a href="https://anaconda.org/conda-forge/gpaw">GPAW</a> |  `docker pull pyiron/pyiron` | 3.87GB |
-| pyiron/experimental | pyiron/base | <a href="https://anaconda.org/conda-forge/temmeta">TEMMETA</a>, <a href="https://anaconda.org/conda-forge/pyprismatic">pyprismatic</a>, <a href="https://anaconda.org/conda-forge/match-series">match-series</a>, <a href="https://anaconda.org/conda-forge/pyxem">pyxem</a>, <a href="https://anaconda.org/conda-forge/pystem">pystem</a> |  `docker pull pyiron/experimental` | 2.73GB |
-| pyiron/damask | pyiron/md | <a href="https://anaconda.org/conda-forge/damask">damask</a>, <a href="https://anaconda.org/conda-forge/sqsgenerator">sqsgenerator</a> |  `docker pull pyiron/damask` | 4.24GB |
-| pyiron/fenics | pyiron/base | <a href="https://anaconda.org/conda-forge/fenics">fenics</a>, <a href="https://anaconda.org/conda-forge/mshr">mshr</a>   | `docker pull pyiron/fenics` | 2.56GB | 
+| Image name | Derived from | Additional Dependencies | Command |
+|------------|--------------|-------------------------|---------|
+| pyiron/base | jupyter/base-notebook | <a href="https://anaconda.org/conda-forge/pyiron">pyiron_base</a> | `docker pull pyiron/base` |
+| pyiron/md | pyiron/base | <a href="https://anaconda.org/conda-forge/lammps">LAMMPS</a>, <a href="https://anaconda.org/conda-forge/pyiron">pyiron</a> and <a href="https://anaconda.org/conda-forge/nglview">nglview</a> | `docker pull pyiron/md` |
+| pyiron/pyiron | pyiron/md | <a href="https://anaconda.org/conda-forge/sphinxdft">SPHInX</a> and <a href="https://anaconda.org/conda-forge/gpaw">GPAW</a> |  `docker pull pyiron/pyiron` |
+| pyiron/experimental | pyiron/base | <a href="https://anaconda.org/conda-forge/temmeta">TEMMETA</a>, <a href="https://anaconda.org/conda-forge/pyprismatic">pyprismatic</a>, <a href="https://anaconda.org/conda-forge/match-series">match-series</a>, <a href="https://anaconda.org/conda-forge/pyxem">pyxem</a>, <a href="https://anaconda.org/conda-forge/pystem">pystem</a> |  `docker pull pyiron/experimental` |
+| pyiron/damask | pyiron/md | <a href="https://anaconda.org/conda-forge/damask">damask</a>, <a href="https://anaconda.org/conda-forge/sqsgenerator">sqsgenerator</a> |  `docker pull pyiron/damask` |
 
 The images also include some examplary notebooks.  
 
@@ -25,8 +24,7 @@ replace `pyiron/pyiron` with the sepecific container you downloaded and to start
 docker run -i -t -p 8888:8888 pyiron/pyiron /bin/bash -c "source /opt/conda/bin/activate; jupyter lab --notebook-dir=/home/pyiron/ --ip='*' --port=8888"
 ```
 To explain the command: `docker run` starts the container in interactive mode `-i` by allocating a pseudo-TTY `-t`. The port `8888` of the docker container instance is forwarded to the local port `8888` the image of choice is `pyiron/pyiron` and inside the image the bash shell is used `/bin/bash` to execute the following command `-c`. First activate the conda environment by sourcing `source /opt/conda/bin/activate` and afterwars start either a jupyter notebook `jupyter notebook` or `jupyter lab` both in the home directory of the pyiron user `--notebook-dir=/home/pyiron/` and allow connections from any IP address `--ip='*'` on port 8888 `--port=8888` which is connected to the outside.   
-
-# Data persistence 
+**Data persistence**  
 You can mount your local drive on the home directory of the docker container via option `-v <local_path>:/home/pyiron/`:  
 ```
 docker run -i -t  -v <local_path>:/home/pyiron/ -p 8888:8888 pyiron/pyiron /bin/bash -c "source /opt/conda/bin/activate; jupyter notebook --notebook-dir=/home/pyiron/ --ip='*' --port=8888"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The resulting images are:
 | pyiron/md | pyiron/base | <a href="https://anaconda.org/conda-forge/lammps">LAMMPS</a>, <a href="https://anaconda.org/conda-forge/pyiron">pyiron</a> and <a href="https://anaconda.org/conda-forge/nglview">nglview</a> | `docker pull pyiron/md` |
 | pyiron/pyiron | pyiron/md | <a href="https://anaconda.org/conda-forge/sphinxdft">SPHInX</a> and <a href="https://anaconda.org/conda-forge/gpaw">GPAW</a> |  `docker pull pyiron/pyiron` |
 | pyiron/experimental | pyiron/base | <a href="https://anaconda.org/conda-forge/temmeta">TEMMETA</a>, <a href="https://anaconda.org/conda-forge/pyprismatic">pyprismatic</a>, <a href="https://anaconda.org/conda-forge/match-series">match-series</a>, <a href="https://anaconda.org/conda-forge/pyxem">pyxem</a>, <a href="https://anaconda.org/conda-forge/pystem">pystem</a> |  `docker pull pyiron/experimental` |
-| pyiron/damask | pyiron/md | <a href="https://anaconda.org/conda-forge/damask">damask</a>, <a href="https://anaconda.org/conda-forge/sqsgenerator">sqsgenerator</a> |  `docker pull pyiron/damask` |
+| pyiron/continuum | pyiron/md | <a href="https://anaconda.org/conda-forge/damask">damask</a>, <a href="https://anaconda.org/conda-forge/sqsgenerator">sqsgenerator</a>, <a href="https://anaconda.org/conda-forge/fenics">fenics</a> |  `docker pull pyiron/continuum` |
 
 The images also include some examplary notebooks.  
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROOT_CONTAINER=jupyter/base-notebook:016833b15ceb
+ARG ROOT_CONTAINER=jupyter/base-notebook:ubuntu-20.04@sha256:9dac2e7ef0b423eb58990e3d8063d84ad7d83c23150cb78923ec59e202c2ed96
 ARG BASE_CONTAINER=$ROOT_CONTAINER
 FROM $BASE_CONTAINER
 
@@ -41,7 +41,7 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/base/environment.yml
+++ b/base/environment.yml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- pyiron_base =0.2.15
+- pyiron_base =0.2.19
 - seaborn =0.11.1

--- a/base/environment.yml
+++ b/base/environment.yml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- pyiron_base =0.2.19
+- pyiron_base =0.2.22
 - seaborn =0.11.1

--- a/continuum/Dockerfile
+++ b/continuum/Dockerfile
@@ -11,14 +11,16 @@ COPY apt.txt /tmp/
 RUN apt-get update -y && \
     xargs -a /tmp/apt.txt apt-get install -y && \
     apt-get clean && \
-    rm /tmp/apt.txt
+    rm /tmp/apt.txt && \
+    sed -i '$d' /opt/conda/conda-meta/pinned
 
 USER $DOCKER_UID
 WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba remove openmpi && \
+    mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/continuum/Dockerfile
+++ b/continuum/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/continuum/environment.yml
+++ b/continuum/environment.yml
@@ -11,5 +11,5 @@ dependencies:
 - sqsgenerator =0.0.5
 - fenics =2019.1.0
 - mshr =2019.1.0
-- pyiron_continuum =0.0.1
+- pyiron_continuum =0.0.2
 - pyiron_gpl =0.0.3

--- a/continuum/environment.yml
+++ b/continuum/environment.yml
@@ -1,13 +1,11 @@
 channels:
 - conda-forge
 dependencies:
-- python =3.8*
-- lammps =2021.05.27=*mpich*
 - damask =3.0.0
 - vtk
 - itkwidgets
 - pyvista
-- pymatgen =2022.0.10
+- pymatgen =2022.0.11
 - sqsgenerator =0.0.5
 - fenics =2019.1.0
 - mshr =2019.1.0

--- a/continuum/environment.yml
+++ b/continuum/environment.yml
@@ -1,6 +1,8 @@
 channels:
 - conda-forge
 dependencies:
+- python =3.8*
+- lammps =2021.05.27=*mpich*
 - damask =3.0.0
 - vtk
 - itkwidgets

--- a/continuum/environment.yml
+++ b/continuum/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - vtk
 - itkwidgets
 - pyvista
-- pymatgen =2022.0.8
+- pymatgen =2022.0.10
 - sqsgenerator =0.0.5
 - fenics =2019.1.0
 - mshr =2019.1.0

--- a/continuum/include_notebooks.sh
+++ b/continuum/include_notebooks.sh
@@ -2,14 +2,9 @@
 git clone https://github.com/pyiron/pyiron_continuum "$HOME"/pyiron_continuum/
 cd "$HOME"/pyiron_continuum/
 cp "$HOME"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "$HOME"/
-cd ..
-git clone https://github.com/materialdigital/pyiron-workflow-damask "$HOME"/pyiron-workflow-damask/
-cd "$HOME"/pyiron-workflow-damask/
-cp "$HOME"/pyiron-workflow-damask/*.ipynb "$HOME"/
-cp -r "$HOME"/pyiron-workflow-damask/Examples/ "$HOME"/
+cp "$HOME"/pyiron_continuum/notebooks/damask_first_steps.ipynb "$HOME"/
 cd ..
 rm -r "$HOME"/pyiron_continuum
-rm -r "$HOME"/pyiron-workflow-damask/
 rm "$HOME"/*.yml
 rm "$HOME"/Dockerfile
 rm "$HOME"/*.sh

--- a/continuum/include_notebooks.sh
+++ b/continuum/include_notebooks.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 git clone https://github.com/pyiron/pyiron_continuum "$HOME"/pyiron_continuum/
-cd "$HOME"/pyiron_continuum/
 cp "$HOME"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "$HOME"/
 cp "$HOME"/pyiron_continuum/notebooks/damask_first_steps.ipynb "$HOME"/
-cd ..
+cp -r "$HOME"/pyiron_continuum/notebooks/damask_inputs "$HOME"/
+
 rm -r "$HOME"/pyiron_continuum
 rm "$HOME"/*.yml
 rm "$HOME"/Dockerfile

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/experimental/environment.yml
+++ b/experimental/environment.yml
@@ -6,6 +6,6 @@ dependencies:
 - pyprismatic =1.2.1
 - match-series =1.0.4
 - pyxem =0.13.3
-- pystem =0.0.25
+- pystem =0.0.26
 - scanf =1.5.2
 - hyperspy =1.6.4

--- a/experimental/environment.yml
+++ b/experimental/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - temmeta =0.0.6
 - pyprismatic =1.2.1
 - match-series =1.0.4
-- pyxem =0.13.2
+- pyxem =0.13.3
 - pystem =0.0.25
 - scanf =1.5.2
-- hyperspy =1.6.2
+- hyperspy =1.6.4

--- a/md/Dockerfile
+++ b/md/Dockerfile
@@ -13,7 +13,7 @@ ENV OMPI_MCA_rmaps_base_oversubscribe=yes
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml && \
+RUN mamba env update -n base -f ${HOME}/environment.yml && \
     conda clean --all -f -y && \
     conda list
 

--- a/md/environment.yml
+++ b/md/environment.yml
@@ -2,8 +2,8 @@ channels:
 - conda-forge
 dependencies:
 - pyiron =0.4.4
-- pyiron_atomistics =0.2.20
+- pyiron_atomistics =0.2.22
 - pyiron-data =0.0.16
 - nglview =3.0.3
-- lammps = 2021.05.27=*openmpi*
+- lammps =2021.05.27=*openmpi*
 - openkim-models =2021.01.28

--- a/md/environment.yml
+++ b/md/environment.yml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - pyiron =0.4.4
-- pyiron_atomistics =0.2.19
+- pyiron_atomistics =0.2.20
 - pyiron-data =0.0.16
 - nglview =3.0.3
 - lammps = 2021.05.27=*openmpi*

--- a/md/environment.yml
+++ b/md/environment.yml
@@ -1,9 +1,9 @@
 channels:
 - conda-forge
 dependencies:
-- pyiron =0.4.3
-- pyiron_atomistics =0.2.14
-- pyiron-data =0.0.14
-- nglview =3.0.1
-- lammps =2021.02.10=*openmpi*_4
+- pyiron =0.4.4
+- pyiron_atomistics =0.2.19
+- pyiron-data =0.0.15
+- nglview =3.0.3
+- lammps = 2021.05.27=*openmpi*
 - openkim-models =2021.01.28

--- a/md/environment.yml
+++ b/md/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - pyiron =0.4.4
 - pyiron_atomistics =0.2.19
-- pyiron-data =0.0.15
+- pyiron-data =0.0.16
 - nglview =3.0.3
 - lammps = 2021.05.27=*openmpi*
 - openkim-models =2021.01.28

--- a/potentialworkshop/Dockerfile
+++ b/potentialworkshop/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/potentialworkshop/environment.yml
+++ b/potentialworkshop/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- sphinxdft =3.0.3
+- sphinxdft =2.7.0
 - atomicrex =1.0.2
 - runner =1.2
 - structdbrest =0.0.1

--- a/potentialworkshop/environment.yml
+++ b/potentialworkshop/environment.yml
@@ -1,13 +1,13 @@
 channels:
 - conda-forge
 dependencies:
-- sphinxdft =2.7.0
-- atomicrex =1.0.1
+- sphinxdft =3.0.3
+- atomicrex =1.0.2
 - runner =1.2
 - structdbrest =0.0.1
-- pyiron_contrib =0.0.10
+- pyiron_contrib =0.0.13
 - pyiron_gpl =0.0.3
-- nbgitpuller =0.9.0
+- nbgitpuller =0.10.1
 - pip
 - pip:
     - pyace-lite

--- a/potentialworkshop/environment.yml
+++ b/potentialworkshop/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - atomicrex =1.0.2
 - runner =1.2
 - structdbrest =0.0.1
-- pyiron_contrib =0.0.13
+- pyiron_contrib =0.0.14
 - pyiron_gpl =0.0.3
 - nbgitpuller =0.10.1
 - pip

--- a/pyiron/Dockerfile
+++ b/pyiron/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda env update -n base -f ${HOME}/environment.yml --prune && \
+RUN mamba env update -n base -f ${HOME}/environment.yml --prune && \
     conda clean --all -f -y && \
     conda list
 

--- a/pyiron/environment.yml
+++ b/pyiron/environment.yml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- sphinxdft =3.0.3
+- sphinxdft =2.7.0
 - gpaw =21.6.0=*openmpi*

--- a/pyiron/environment.yml
+++ b/pyiron/environment.yml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- sphinxdft =2.7.0
-- gpaw =21.1.0=*openmpi*
+- sphinxdft =3.0.3
+- gpaw =21.6.0=*openmpi*


### PR DESCRIPTION
- updating the Base image to jupyter/base-notebook:ubuntu-20.04
    The old taging was confusing at least for me with a large number; therefore I prefer to have a meaningful tag name.  I checked the size of image and it is even smaller using this named tag. To update the name_tag, we can update the hash digest via `@sha256:digest_number`
- using mamba to make the build process faster
- update the dependencies
- updated the readme
