### PR TITLE
Cleanup $HOME of all containers

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,10 +22,10 @@ jobs:
       - run: docker build -t pyiron/experimental:latest experimental/
       - run: docker tag pyiron/experimental:latest pyiron/experimental:"$(date +%F)"
       - run: docker images
-      - run: docker run --rm pyiron/continuum /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
-      - run: docker run --rm pyiron/base /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'  
-      - run: docker run --rm pyiron/pyiron /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
-      - run: docker run --rm pyiron/experimental /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls ~/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
+      - run: docker run --rm pyiron/continuum /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls "${HOME}"/notebooks_*/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
+      - run: docker run --rm pyiron/base /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls "${HOME}"/notebooks_*/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'  
+      - run: docker run --rm pyiron/pyiron /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls "${HOME}"/notebooks_*/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
+      - run: docker run --rm pyiron/experimental /bin/bash -c 'source /opt/conda/bin/activate; i=0; for f in $(ls "${HOME}"/notebooks_*/*.ipynb); do jupyter nbconvert --ExecutePreprocessor.timeout=9999999 --to notebook --execute $f || i=$((i+1)); done; if [ $i -gt 0 ]; then exit 1; fi;'
       - run: mkdir -p environment; chmod 777 environment
       - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/base /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/pyiron_base_$(date +%F).yml;' 
       - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/md /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/pyiron_md_$(date +%F).yml;' 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,6 +50,7 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
 
 # Fix permissions on /etc/jupyter as root
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_base
 RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash include_notebooks.sh &&\
     fix-permissions /etc/jupyter/ &&\

--- a/base/include_notebooks.sh
+++ b/base/include_notebooks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+NOTEBOOK_DIR="${HOME}"/notebooks_base
 git clone https://github.com/pyiron/pyiron_base
-cp -r "$HOME"/pyiron_base/notebooks/*.ipynb "$HOME"/
+cp -r "$HOME"/pyiron_base/notebooks/*.ipynb "$NOTEBOOK_DIR"
 rm -r "$HOME"/pyiron_base
 rm "$HOME"/*.yml
 rm "$HOME"/Dockerfile

--- a/base/include_notebooks.sh
+++ b/base/include_notebooks.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-NOTEBOOK_DIR="${HOME}"/notebooks_base
 mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/pyiron_base
 cp -r "$HOME"/pyiron_base/notebooks/*.ipynb "$NOTEBOOK_DIR"

--- a/base/include_notebooks.sh
+++ b/base/include_notebooks.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 NOTEBOOK_DIR="${HOME}"/notebooks_base
+mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/pyiron_base
 cp -r "$HOME"/pyiron_base/notebooks/*.ipynb "$NOTEBOOK_DIR"
 rm -r "$HOME"/pyiron_base

--- a/continuum/Dockerfile
+++ b/continuum/Dockerfile
@@ -25,8 +25,7 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
 
 USER root
 ENV NOTEBOOK_DIR=${HOME}/notebooks_continuum
-RUN rm ${HOME}/*.ipynb &&\
-    chmod +x ${HOME}/include_notebooks.sh && \
+RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash ${HOME}/include_notebooks.sh && \
     fix-permissions ${HOME} && \
     fix-permissions $CONDA_DIR

--- a/continuum/Dockerfile
+++ b/continuum/Dockerfile
@@ -24,11 +24,12 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
     mamba list
 
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_continuum
 RUN rm ${HOME}/*.ipynb &&\
     chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash ${HOME}/include_notebooks.sh && \
     fix-permissions ${HOME} && \
-    fix-permissions $CONDA_DIRs
+    fix-permissions $CONDA_DIR
 
 # Switch back to pyiron to avoid accidental container runs as root
 USER $DOCKER_UID

--- a/continuum/include_notebooks.sh
+++ b/continuum/include_notebooks.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-git clone https://github.com/pyiron/pyiron_continuum "$HOME"/pyiron_continuum/
-cp "$HOME"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "$HOME"/
-cp "$HOME"/pyiron_continuum/notebooks/damask_tutorial.ipynb "$HOME"/
-
-rm -r "$HOME"/pyiron_continuum
-rm "$HOME"/*.yml
-rm "$HOME"/Dockerfile
-rm "$HOME"/*.sh
+mkdir ${NOTEBOOK_DIR}
+git clone https://github.com/pyiron/pyiron_continuum
+cp "${HOME}"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "${NOTEBOOK_DIR}"
+cp "${HOME}"/pyiron_continuum/notebooks/damask_tutorial.ipynb "${NOTEBOOK_DIR}"
+rm -r "${HOME}"/pyiron_continuum
+rm "${HOME}"/*.yml
+rm "${HOME}"/Dockerfile
+rm "${HOME}"/*.sh

--- a/continuum/include_notebooks.sh
+++ b/continuum/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone https://github.com/pyiron/pyiron_continuum
+git clone https://github.com/pyiron/pyiron_continuum.git
 cp "${HOME}"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "${NOTEBOOK_DIR}"
 cp "${HOME}"/pyiron_continuum/notebooks/damask_tutorial.ipynb "${NOTEBOOK_DIR}"
 rm -r "${HOME}"/pyiron_continuum

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -14,6 +14,7 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
     mamba list
 
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_experimental
 RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash ${HOME}/include_notebooks.sh && \
     fix-permissions $CONDA_DIR && \

--- a/experimental/include_notebooks.sh
+++ b/experimental/include_notebooks.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+mkdir ${NOTEBOOK_DIR} 
 git clone https://github.com/pyiron/pyiron_experimental pyiron_experimental_repo
-cp "$HOME"/pyiron_experimental_repo/notebooks/*.ipynb "$HOME"/
-cp "$HOME"/pyiron_experimental_repo/notebooks/*.tif "$HOME"/
-cp "$HOME"/pyiron_experimental_repo/notebooks/*.emd "$HOME"/
-cp -r "$HOME"/pyiron_experimental_repo/pyiron_experimental "$HOME"/
-rm -r "$HOME"/pyiron_experimental_repo
+cp "$HOME"/pyiron_experimental_repo/notebooks/*.ipynb "${NOTEBOOK_DIR}"
+cp "$HOME"/pyiron_experimental_repo/notebooks/*.tif "${NOTEBOOK_DIR}"
+cp "$HOME"/pyiron_experimental_repo/notebooks/*.emd "${NOTEBOOK_DIR}"
+cp -r "$HOME"/pyiron_experimental_repo/pyiron_experimental "${NOTEBOOK_DIR}"
+rm -rf "$HOME"/pyiron_experimental_repo
 rm "$HOME"/Dockerfile
 rm "$HOME"/*.sh
 rm "$HOME"/*.yml

--- a/md/Dockerfile
+++ b/md/Dockerfile
@@ -18,6 +18,7 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
     mamba list
 
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_atomistics
 RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash include_notebooks.sh &&\
     fix-permissions ${HOME} && \

--- a/md/exclude
+++ b/md/exclude
@@ -3,5 +3,4 @@ energy_volume_curve.ipynb
 hcp_workfunction.ipynb
 sqs.ipynb
 test_pyiron_installation.ipynb
-tests_sphinx_sphinx_check_all.ipynb
 phonopy_example.ipynb

--- a/md/include_notebooks.sh
+++ b/md/include_notebooks.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+NOTEBOOK_DIR="${HOME}"/notebooks_atomistics
+mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/pyiron_atomistics
-cp -r "$HOME"/pyiron_atomistics/notebooks/*.ipynb "$HOME"/
+cp -r "$HOME"/pyiron_atomistics/notebooks/*.ipynb "$NOTEBOOK_DIR"
 rm -r "$HOME"/pyiron_atomistics
 for f in $(cat "$HOME"/exclude); do rm "$HOME"/$f; done;
 rm "$HOME"/*.yml

--- a/md/include_notebooks.sh
+++ b/md/include_notebooks.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-NOTEBOOK_DIR="${HOME}"/notebooks_atomistics
 mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/pyiron_atomistics
-cp -r "$HOME"/pyiron_atomistics/notebooks/*.ipynb "$NOTEBOOK_DIR"
-rm -r "$HOME"/pyiron_atomistics
-for f in $(cat "$HOME"/exclude); do rm "$HOME"/$f; done;
-rm "$HOME"/*.yml
-rm "$HOME"/Dockerfile
-rm "$HOME"/exclude
-rm "$HOME"/*.sh
+cp -r "${HOME}"/pyiron_atomistics/notebooks/*.ipynb "${NOTEBOOK_DIR}"
+rm -r "${HOME}"/pyiron_atomistics
+for f in $(cat "${HOME}"/exclude); do rm "${NOTEBOOK_DIR}"/$f; done;
+rm "${HOME}"/*.yml
+rm "${HOME}"/Dockerfile
+rm "${HOME}"/exclude
+rm "${HOME}"/*.sh

--- a/potentialworkshop/Dockerfile
+++ b/potentialworkshop/Dockerfile
@@ -14,6 +14,7 @@ RUN mamba env update -n base -f ${HOME}/environment.yml && \
     mamba list
 
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_potentialworkshop
 RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash include_notebooks.sh &&\
     fix-permissions $CONDA_DIR && \

--- a/potentialworkshop/include_notebooks.sh
+++ b/potentialworkshop/include_notebooks.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/potentials-workshop-2021.git
-cp -r "$HOME"/pyiron_potentialfit/day_* "$HOME"/
+cp -r "$HOME"/potentials-workshop-2021/day_* "${NOTEBOOK_DIR}"
 rm -r "$HOME"/potentials-workshop-2021
+rm apt.txt
+rm Dockerfile
+rm *.yml
+rm exclude
+rm *.sh

--- a/pyiron/Dockerfile
+++ b/pyiron/Dockerfile
@@ -9,12 +9,13 @@ WORKDIR $HOME
 ARG PYTHON_VERSION=default
 
 COPY . ${HOME}/
-RUN conda install -n base -c defaults mkl=2023.2.0 && \
+RUN mamba install -n base -c defaults mkl=2023.2.0 && \
     mamba env update -n base -f ${HOME}/environment.yml && \
     mamba clean --all -f -y && \
     mamba list
 
 USER root
+ENV NOTEBOOK_DIR=${HOME}/notebooks_pyiron
 RUN chmod +x ${HOME}/include_notebooks.sh && \
     /bin/bash include_notebooks.sh &&\
     fix-permissions $CONDA_DIR && \

--- a/pyiron/include_notebooks.sh
+++ b/pyiron/include_notebooks.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+mkdir ${NOTEBOOK_DIR}
 git clone https://github.com/pyiron/pyiron
-cp -r "$HOME"/pyiron/notebooks/*.ipynb "$HOME"/
-rm -r "$HOME"/pyiron
-for f in $(cat "$HOME"/exclude); do rm "$HOME"/$f; done;
-rm "$HOME"/Dockerfile
-rm "$HOME"/exclude
-rm "$HOME"/*.sh
-rm "$HOME"/*.yml
+cp -r "${HOME}"/pyiron/notebooks/*.ipynb "${NOTEBOOK_DIR}"
+rm -r "${HOME}"/pyiron
+for f in $(cat "${HOME}"/exclude); do rm "${NOTEBOOK_DIR}"/$f; done;
+rm "${HOME}"/Dockerfile
+rm "${HOME}"/exclude
+rm "${HOME}"/*.sh
+rm "${HOME}"/*.yml


### PR DESCRIPTION
While working on some new images, I realized that when running our more "downstream" containers (e.g. pyiron or continuum), their home directory is overcrowded with unordered notebooks. So I iterated through all images and ordered notebooks corresponding to the packag(es) they provide examples for. This means, there are now directories like "notebooks_base" or "notebooks_atomistics" containing corresponding notebooks.