### PR TITLE
Add llama-index=0.10.28 to cmti

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -21,3 +21,4 @@ dependencies:
 - psycopg2 =2.9.9
 - netCDF4 =1.6.5
 - numba =0.59.0
+- llama-index =0.10.6

--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -21,4 +21,4 @@ dependencies:
 - psycopg2 =2.9.9
 - netCDF4 =1.6.5
 - numba =0.59.0
-- llama-index =0.10.28
+- llama-index =0.10.31

--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -21,4 +21,4 @@ dependencies:
 - psycopg2 =2.9.9
 - netCDF4 =1.6.5
 - numba =0.59.0
-- llama-index =0.10.6
+- llama-index =0.10.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ temmeta==0.0.6
 vtk==9.2.6
 pytorch==2.0.0
 tensorflow==2.15.0
+llama-index==0.10.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ temmeta==0.0.6
 vtk==9.2.6
 pytorch==2.0.0
 tensorflow==2.15.0
-llama-index==0.10.6
+llama-index==0.10.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ temmeta==0.0.6
 vtk==9.2.6
 pytorch==2.0.0
 tensorflow==2.15.0
-llama-index==0.10.28
+llama-index==0.10.31


### PR DESCRIPTION
Add `llama-index` as additional dependency to provide pyiron users with large language model support. 