### PR TITLE
Checkout correct version of Jupyter notebooks

### DIFF
--- a/base/include_notebooks.sh
+++ b/base/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone https://github.com/pyiron/pyiron_base
+git clone --single-branch --branch pyiron_base-$(grep pyiron_base environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron_base.git
 cp -r "$HOME"/pyiron_base/notebooks/*.ipynb "$NOTEBOOK_DIR"
 rm -r "$HOME"/pyiron_base
 rm "$HOME"/*.yml

--- a/continuum/include_notebooks.sh
+++ b/continuum/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone https://github.com/pyiron/pyiron_continuum.git
+git clone --single-branch --branch pyiron_continuum-$(grep pyiron_continuum environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron_continuum.git
 cp "${HOME}"/pyiron_continuum/notebooks/fenics_tutorial.ipynb "${NOTEBOOK_DIR}"
 cp "${HOME}"/pyiron_continuum/notebooks/damask_tutorial.ipynb "${NOTEBOOK_DIR}"
 rm -r "${HOME}"/pyiron_continuum

--- a/experimental/include_notebooks.sh
+++ b/experimental/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR} 
-git clone https://github.com/pyiron/pyiron_experimental pyiron_experimental_repo
+git clone --single-branch --branch pyiron_experimental-$(grep pyiron_experimental environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron_experimental.git pyiron_experimental_repo
 cp "$HOME"/pyiron_experimental_repo/notebooks/*.ipynb "${NOTEBOOK_DIR}"
 cp "$HOME"/pyiron_experimental_repo/notebooks/*.tif "${NOTEBOOK_DIR}"
 cp "$HOME"/pyiron_experimental_repo/notebooks/*.emd "${NOTEBOOK_DIR}"

--- a/md/include_notebooks.sh
+++ b/md/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone https://github.com/pyiron/pyiron_atomistics
+git clone --single-branch --branch pyiron_atomistics-$(grep pyiron_atomistics environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron_atomistics.git
 cp -r "${HOME}"/pyiron_atomistics/notebooks/*.ipynb "${NOTEBOOK_DIR}"
 rm -r "${HOME}"/pyiron_atomistics
 for f in $(cat "${HOME}"/exclude); do rm "${NOTEBOOK_DIR}"/$f; done;

--- a/pyiron/include_notebooks.sh
+++ b/pyiron/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone https://github.com/pyiron/pyiron
+git clone --single-branch --branch pyiron-$(grep pyiron environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron.git
 cp -r "${HOME}"/pyiron/notebooks/*.ipynb "${NOTEBOOK_DIR}"
 rm -r "${HOME}"/pyiron
 for f in $(cat "${HOME}"/exclude); do rm "${NOTEBOOK_DIR}"/$f; done;

--- a/pyiron/include_notebooks.sh
+++ b/pyiron/include_notebooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir ${NOTEBOOK_DIR}
-git clone --single-branch --branch pyiron-$(grep pyiron environment.yml | tr "=" "\n" | sed '$!d')  https://github.com/pyiron/pyiron.git
+git clone https://github.com/pyiron/pyiron
 cp -r "${HOME}"/pyiron/notebooks/*.ipynb "${NOTEBOOK_DIR}"
 rm -r "${HOME}"/pyiron
 for f in $(cat "${HOME}"/exclude); do rm "${NOTEBOOK_DIR}"/$f; done;


### PR DESCRIPTION
Previously the Jupyter notebooks were checked out from the `main` branch, now the Jupyter notebooks corresponding to the specific version of the corresponding pyiron package are used. 