### PR TITLE
Add jupyter-server-proxy to CMTI

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -22,3 +22,4 @@ dependencies:
 - netCDF4 =1.6.5
 - numba =0.59.0
 - llama-index =0.10.31
+- jupyter-server-proxy =4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ fenics==2019.1.0
 gpaw==24.1.0
 hyperspy==2.0.1
 ipywidgets==8.1.2
+jupyter-server-proxy==4.1.2
 maggma==0.65.0
 nbgitpuller==1.2.1
 nglview==3.1.2


### PR DESCRIPTION
This is needed to enable the JHub to spawn and redirect to a vscode server. @jan-janssen, changing the requirements.txt is needed to enable dependabot for this dependency, isn't it?