### PR TITLE
Add pyiron_snippets to cmti config

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - pyiron_potentialfit =0.2.0
 - pyiron_workflow =0.9.0
 - pyiron_gui =0.0.12
+- pyiron_snippets =0.1.1
 - matgl =0.9.2
 - mlip =2.0
 - sqsgenerator =0.3


### PR DESCRIPTION
I've also noticed that neither base nore atomistics are explicitly pinned right now.  @niklassiemer Can you add the current version used in say pyiron/latest?