### PR TITLE
Add executorlib

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - pyiron_potentialfit =0.3.2
 - pyiron_workflow =0.9.1
 - pyiron_gui =0.0.12
+- executorlib =0.0.1
 - matgl =0.9.2
 - mlip =2.0
 - sqsgenerator =0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pyiron_workflow==0.9.1
 pyiron-gpl==0.0.5
 pyiron_snippets==0.1.1
 pyiron_potentialfit==0.3.2
+executorlib==0.0.1
 calphy==1.3.8
 damask==3.0.0a8
 fenics==2019.1.0


### PR DESCRIPTION
I was a bit confused, was pympipool not part of the cmti env previously or did it get removed during the rename?  Anyway, would be good to have it, assuming it is stable now.