### PR TITLE
Revert grouping of pyiron dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  groups:
-    pyiron:
-      applies-to: version-updates
-      patterns:
-        - "pyiron*"
   open-pull-requests-limit: 10


### PR DESCRIPTION
This breaks the auto `environment.yml` updates