### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,12 +43,6 @@ jobs:
           tail --lines=+5 base/environment.yml >> experimental/environment.yml
           docker build -t pyiron/experimental:latest experimental/
           docker tag pyiron/experimental:latest pyiron/experimental:"$(date +%F)"
-      - name: Build pyiron/mpie_cmti
-        timeout-minutes: 5
-        run: |
-          tail --lines=+5 pyiron/environment.yml >> mpie_cmti/environment.yml
-          docker build -t pyiron/mpie_cmti:latest mpie_cmti/
-          docker tag pyiron/mpie_cmti:latest pyiron/mpie_cmti:"$(date +%F)"
       # Testing
       - run: docker images
       - name: Test pyiron/continuum
@@ -71,6 +65,16 @@ jobs:
       - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/pyiron /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/pyiron_pyiron_$(date +%F).yml;' 
       - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/potentialworkshop /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/pyiron_potentialworkshop_$(date +%F).yml;' 
       - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/experimental /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/pyiron_experimental_$(date +%F).yml;'
-      - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/mpie_cmti /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/mpie_cmti_$(date +%F).yml;'
       - run: ls -al environment
-      
+  build_cmti:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build pyiron/mpie_cmti
+        timeout-minutes: 15
+        run: |
+          docker build -t pyiron/mpie_cmti:latest mpie_cmti/
+          docker tag pyiron/mpie_cmti:latest pyiron/mpie_cmti:"$(date +%F)"
+      - run: docker images
+      - run: mkdir -p environment; chmod 777 environment
+      - run: docker run -v $(pwd)/environment:/home/jovyan/ --rm pyiron/mpie_cmti /bin/bash -c 'source /opt/conda/bin/activate; conda env export > /home/jovyan/mpie_cmti_$(date +%F).yml;'


### PR DESCRIPTION
Refactors some of the workflows in this repository's actions.
A fist step was done in #426 , but I think it's cleaner to separate these activities. The fist commit just takes the changes to `testing.yml` done over there (@niklassiemer) to this PR.

We want to 
- build images defined in this repository on seperate runners (avoids running out of disk-space)
- do some generalizations to reduce redundant sections in the workflow definitions.

I'll add things to this list, as I'm doing the changes.