### PR TITLE
Add import test in testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -123,7 +123,7 @@ jobs:
           key: cmti_env_-${{ steps.date.outputs.date }}
       - name: test pyiron/cmti
         run: |
-          docker run -v $(pwd)/mpie_cmti/test:/home/jovyan/test --rm pyiron/mpie_cmti /bin/bash -c 'source /opt/conda/bin/activate; python -Werror test/import.py;'
+          docker run -v $(pwd)/mpie_cmti/test:/home/jovyan/test --rm pyiron/mpie_cmti /bin/bash -c 'source /opt/conda/bin/activate; python test/import.py;'
   check:
     needs: [build, build_cmti]
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -121,6 +121,9 @@ jobs:
         with:
           path: environment/*.yml
           key: cmti_env_-${{ steps.date.outputs.date }}
+      - name: test pyiron/cmti
+        run: |
+          docker run -v $(pwd)/mpie_cmti/test:/home/jovyan/test --rm pyiron/mpie_cmti /bin/bash -c 'source /opt/conda/bin/activate; python -Werror test/import.py;'
   check:
     needs: [build, build_cmti]
     runs-on: ubuntu-latest

--- a/mpie_cmti/test/import.py
+++ b/mpie_cmti/test/import.py
@@ -1,0 +1,1 @@
+from pyiron import Project


### PR DESCRIPTION
On cmti 
```python
from pyiron import Project
```
currently fails with the latest release (see https://github.com/pyiron/pyiron_atomistics/issues/1751?notification_referrer_id=NT_kwDOBDT46rQxNzE3NDY5OTQxODo3MDU4MDQ1OA). A fix is already released with [pyiron_contrib version 0.1.19](https://github.com/pyiron/pyiron_contrib/releases/tag/pyiron_contrib-0.1.19).

However, this should not have entered on cmti in the first place - tests like this one were missing!