### PR TITLE
Add backports.tarfile

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -44,3 +44,4 @@ dependencies:
 - tensorflow =2.17.0
 - dscribe =2.1.1
 - landau =1.3.1
+- backports.tarfile


### PR DESCRIPTION
I am not sure why this is needed, it seems something in the setuptools or the like dropped this dependency which is needed by others...