### PR TITLE
Use older sysroot_linux-64=2.17

### DIFF
--- a/mpie_cmti/environment.yml
+++ b/mpie_cmti/environment.yml
@@ -41,6 +41,7 @@ dependencies:
 - sphinxdft =3.1
 - sqsgenerator =0.3
 - structdbrest =0.0.1
+- sysroot_linux-64 =2.17
 - tensorflow =2.17.0
 - dscribe =2.1.1
 - landau =1.3.1


### PR DESCRIPTION
This was working and 
Could not solve for environment specs
The following package could not be installed
└─ sysroot_linux-64 ==2.34 h087de78_2 is not installable because it requires
   └─ __glibc >=2.34 , which is missing on the system.